### PR TITLE
Oauth 返回不正确

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 home assistant custom component for tmall genie
 
 basicly it's a gate and wrapper of Yonsm's gate in https://github.com/Yonsm/HAExtra/tree/master/hagenie
+
+The version support custom suffix to avoid the "deviceid duplicate" issue if these id is already in the tmall genie.


### PR DESCRIPTION
不知道是不是最近天猫精灵服务器修改了。
原来还可以正常使用的，但是发现不会添加新设备了，之后尝试解绑，就无法在重新绑定成功。
一直提示Oauth 返回不正确